### PR TITLE
.drone.yml config updates

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,13 +1,13 @@
 pipeline:
   publish:
     image: plugins/ecr
-    secrets: [ ecr_access_key, ecr_secret_key]
+    secrets: [ecr_access_key, ecr_secret_key]
     registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
     repo: 795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME}
     create_repository: true
     tags:
-    - git-${DRONE_COMMIT_SHA:0:7}
-    - latest
+      - git-${DRONE_COMMIT_SHA:0:7}
+      - latest
     when:
       branch: [master, staging]
       event: push
@@ -19,13 +19,13 @@ pipeline:
     environment:
       - API_SERVER=https://api.staging.mongodb.sh
     prefix: STAGING
-    secrets: [ staging_kubernetes_token ]
+    secrets: [staging_kubernetes_token]
     helm_repos: mongodb=https://10gen-ops.github.io/helm-charts
     chart: mongodb/web-app
     chart_version: 3.1.0
     tiller_ns: docs
     client_only: true
-    values_files: [ "environments/prod.yml" ]
+    values_files: ["environments/prod.yml"]
     values: "image.tag=git-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=marian.docs.staging.mongodb.sh,ingress.hosts[1]=marian.docs.staging.corp.mongodb.com"
     when:
       branch: staging
@@ -38,13 +38,13 @@ pipeline:
     environment:
       - API_SERVER=https://api.prod.mongodb.sh
     prefix: PROD
-    secrets: [ prod_kubernetes_token ]
+    secrets: [prod_kubernetes_token]
     helm_repos: mongodb=https://10gen-ops.github.io/helm-charts
     chart: mongodb/web-app
     chart_version: 3.1.0
     tiller_ns: docs
     client_only: true
-    values_files: [ "environments/prod.yml" ]
+    values_files: ["environments/prod.yml"]
     values: "image.tag=git-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=marian.docs.prod.mongodb.sh,ingress.hosts[1]=marian.docs.prod.corp.mongodb.com"
     when:
       branch: master

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,39 +13,39 @@ pipeline:
       event: push
 
   deploy-staging:
-    image: quay.io/ipedrazas/drone-helm
+    image: quay.io/mongodb/drone-helm:v2.14.1-0.1.0
     release: marian
     namespace: docs
     environment:
-      - API_SERVER=https://api.staging.mongodb.sh
+      - API_SERVER=https://api.staging.corp.mongodb.com
     prefix: STAGING
     secrets: [staging_kubernetes_token]
-    helm_repos: mongodb=https://10gen-ops.github.io/helm-charts
+    helm_repos: mongodb=https://10gen.github.io/helm-charts
     chart: mongodb/web-app
     chart_version: 3.1.0
     tiller_ns: docs
     client_only: true
     values_files: ["environments/prod.yml"]
-    values: "image.tag=git-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=marian.docs.staging.mongodb.sh,ingress.hosts[1]=marian.docs.staging.corp.mongodb.com"
+    values: "image.tag=git-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=marian.docs.staging.corp.mongodb.com"
     when:
       branch: staging
       event: push
 
   deploy-prod:
-    image: quay.io/ipedrazas/drone-helm
+    image: quay.io/mongodb/drone-helm:v2.14.1-0.1.0
     release: marian
     namespace: docs
     environment:
-      - API_SERVER=https://api.prod.mongodb.sh
+      - API_SERVER=https://api.prod.corp.mongodb.com
     prefix: PROD
     secrets: [prod_kubernetes_token]
-    helm_repos: mongodb=https://10gen-ops.github.io/helm-charts
+    helm_repos: mongodb=https://10gen.github.io/helm-charts
     chart: mongodb/web-app
     chart_version: 3.1.0
     tiller_ns: docs
     client_only: true
     values_files: ["environments/prod.yml"]
-    values: "image.tag=git-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=marian.docs.prod.mongodb.sh,ingress.hosts[1]=marian.docs.prod.corp.mongodb.com"
+    values: "image.tag=git-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=marian.docs.prod.corp.mongodb.com"
     when:
       branch: master
       event: push


### PR DESCRIPTION
We are retiring the `mongodb.sh` domain, therefore all ingresses need to move to `corp.mongodb.com` host names. Also, updating `.drone.yml` to our current quay helm plugin and helm charts repo.