### PR TITLE
DOP-1312 Add Access-Control-Allow-Origin to Status Endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -387,7 +387,8 @@ class Marian {
         const headers = {
             'Content-Type': 'application/json',
             'Vary': 'Accept-Encoding',
-            'Pragma': 'no-cache'
+            'Pragma': 'no-cache',
+            'Access-Control-Allow-Origin': '*',
         }
         Object.assign(headers, STANDARD_HEADERS)
 


### PR DESCRIPTION
For the Search UI, we need to query the `status` endpoint to get the series of manifests which a user can choose from. I noticed we provide the `Access-Control-Allow-Origin` header for `/search` but not on `/status`, which blocks programmatic requests.

This PR adds the response header to allow programmatic access to `/status`.